### PR TITLE
Add support for non-ERC721 tokens

### DIFF
--- a/src/routes/process.svelte
+++ b/src/routes/process.svelte
@@ -155,6 +155,7 @@
 			asset: {
 				tokenId: item.token_id,
 				tokenAddress: item.asset_contract.address,
+				schemaName: item.asset_contract.schema_name,
 			},
 			startAmount: price,
 			endAmount: price,


### PR DESCRIPTION
Tested and working with https://opensea.io/collection/amulets-v4 (ERC-1155)